### PR TITLE
Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Please see the documentation for all configuration options:
+# <https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates>
+
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+        # These are peer deps of Cargo and should not be automatically bumped
+        - dependency-name: "semver"
+        - dependency-name: "crates-io"
+    rebase-strategy: "disabled"
+


### PR DESCRIPTION
Dependabot is a tool provided by Github to help you manage dependencies effectively. While Dependabot itself is not a CI tool, it is a great complement for any CI/CD pipeline on Github. Without it, you will often otherwise having to spend time manually checking dependency versions.